### PR TITLE
Fix URL prefix in router

### DIFF
--- a/starter-code/routes/drones.js
+++ b/starter-code/routes/drones.js
@@ -5,16 +5,16 @@ const express = require('express');
 const router = express.Router();
 
 
-router.get('/drones', (req, res, next) => {
+router.get('/', (req, res, next) => {
   // Iteration #2
 });
 
 
-router.get('/drones/new', (req, res, next) => {
+router.get('/new', (req, res, next) => {
   // Iteration #3
 });
 
-router.post('/drones', (req, res, next) => {
+router.post('/', (req, res, next) => {
   // Iteration #3
 });
 


### PR DESCRIPTION
Just encountered this issue during onboarding. You either need to put the URL prefix in `app.js` OR you put the URL in the routes of the router file. Not both.

Generally speaking I prefer to leave the prefixes in the router file because it's less confusing for students. For example:

```js
// app.js
const drones = require('./routes/drones');
app.use(drones);
```

```js
// routes/drones.js
router.get('/drones/new', (req, res, next) => {
  // ...
});
```

Anyway, this is for a later discussion.